### PR TITLE
PR to add functionality to allow close buttons of Desktop Window to be optionally disabled

### DIFF
--- a/gui/choc_DesktopWindow.h
+++ b/gui/choc_DesktopWindow.h
@@ -663,8 +663,11 @@ struct DesktopWindow::Pimpl
 
     void setClosable (bool b)
     {
-        enabledCloseButton = b;
-    }
+        if (b) 
+            EnableMenuItem(GetSystemMenu(hwnd, FALSE), SC_CLOSE, MF_BYCOMMAND | MF_ENABLED);           
+        else
+            EnableMenuItem(GetSystemMenu(hwnd, FALSE), SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+    } 
 
     void setMinimumSize (int w, int h)
     {
@@ -723,8 +726,6 @@ private:
     HWNDHolder hwnd;
     POINT minimumSize = {}, maximumSize = {};
     WindowClass windowClass { L"CHOCWindow", (WNDPROC) wndProc };
-
-    bool enabledCloseButton = true;
 
     Bounds scaleBounds (Bounds b, double scale)
     {
@@ -799,7 +800,7 @@ private:
         {
             case WM_NCCREATE:        enableNonClientDPIScaling (h); break;
             case WM_SIZE:            if (auto w = getPimpl (h)) w->handleSizeChange(); break;
-            case WM_CLOSE:           if (auto w = getPimpl (h)) if (w->enabledCloseButton) if (w->owner.windowClosed != nullptr) w->owner.windowClosed(); return 0;
+            case WM_CLOSE:           if (auto w = getPimpl (h)) w->handleClose(); return 0;
             case WM_GETMINMAXINFO:   if (auto w = getPimpl (h)) w->getMinMaxInfo (*(LPMINMAXINFO) lp); return 0;
             default:                 break;
         }

--- a/gui/choc_DesktopWindow.h
+++ b/gui/choc_DesktopWindow.h
@@ -329,8 +329,10 @@ struct DesktopWindow::Pimpl
     void setResizable (bool b)
     {
         CHOC_AUTORELEASE_BEGIN
-        auto style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable
-                        | (b ? NSWindowStyleMaskResizable : 0);
+        objc::AutoReleasePool autoreleasePool;
+        auto style = objc::call<unsigned long> (window, "styleMask");
+        style = style | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable
+                      | (b ? NSWindowStyleMaskResizable : 0);
 
         objc::call<void> (window, "setStyleMask:", (unsigned long) style);
         CHOC_AUTORELEASE_END

--- a/gui/choc_DesktopWindow.h
+++ b/gui/choc_DesktopWindow.h
@@ -331,9 +331,7 @@ struct DesktopWindow::Pimpl
         CHOC_AUTORELEASE_BEGIN
         objc::AutoReleasePool autoreleasePool;
         auto style = objc::call<unsigned long> (window, "styleMask");
-        style = style | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable
-                      | (b ? NSWindowStyleMaskResizable : 0);
-
+        style = style | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | (b ? NSWindowStyleMaskResizable : 0);
         objc::call<void> (window, "setStyleMask:", (unsigned long) style);
         CHOC_AUTORELEASE_END
     }
@@ -342,10 +340,8 @@ struct DesktopWindow::Pimpl
     {
         CHOC_AUTORELEASE_BEGIN
         objc::AutoReleasePool autoreleasePool;
-
         auto style = objc::call<unsigned long> (window, "styleMask");
-        style = closable ? (style | NSWindowStyleMaskClosable)
-                         : (style & ~NSWindowStyleMaskClosable);
+        style = closable ? (style | NSWindowStyleMaskClosable) : (style & ~NSWindowStyleMaskClosable);
         objc::call<void> (window, "setStyleMask:", (unsigned long) style);
         CHOC_AUTORELEASE_END
     }

--- a/gui/choc_DesktopWindow.h
+++ b/gui/choc_DesktopWindow.h
@@ -338,12 +338,14 @@ struct DesktopWindow::Pimpl
     
     void setClosable (bool closable)
     {
+        CHOC_AUTORELEASE_BEGIN
         objc::AutoReleasePool autoreleasePool;
 
         auto style = objc::call<unsigned long> (window, "styleMask");
         style = closable ? (style | NSWindowStyleMaskClosable)
                          : (style & ~NSWindowStyleMaskClosable);
         objc::call<void> (window, "setStyleMask:", (unsigned long) style);
+        CHOC_AUTORELEASE_END
     }
 
     void setMinimumSize (int w, int h) { CHOC_AUTORELEASE_BEGIN objc::call<void> (window, "setContentMinSize:", createCGSize (w, h)); CHOC_AUTORELEASE_END }


### PR DESCRIPTION
Added new function `setClosable()` to `choc_DesktopWindow.h` that allows the Close button to be disabled under Win, MacOS and Linux.