### PR TITLE
fix unzipping zipped folders

### DIFF
--- a/containers/choc_ZipFile.h
+++ b/containers/choc_ZipFile.h
@@ -359,7 +359,7 @@ inline bool ZipFile::Item::uncompressToFile (const std::filesystem::path& target
 
     if (isFolder())
     {
-        if (! create_directories (targetFile))
+        if (! create_directories (targetFile) && ! exists(targetFile))
             throw std::runtime_error ("Failed to create folder: " + targetFile.string());
 
         return true;


### PR DESCRIPTION
For me this code fails
```
int main(int argc, const char **argv) {
  /*test.zip contains of
  --testfolder/
  ----test.txt
  */
  auto stream = std::make_shared<std::ifstream>("test.zip", std::ios::binary);
  choc::zip::ZipFile zipFile(stream);

  zipFile.uncompressToFolder("out", true, false);
}
```

Throws here 
```
if (! create_directories (targetFile))
            throw std::runtime_error ("Failed to create folder: " + targetFile.string());
```
even though the directory was actually created. The reason seems to be the last slash and some ambiguity in the standard.
I think it will return false if the last directory was not "created" which is "/"
[https://stackoverflow.com/questions/60130796/return-value-of-stdfilesystemcreate-directories-on-paths-with-trailing-sla](https://stackoverflow.com/questions/60130796/return-value-of-stdfilesystemcreate-directories-on-paths-with-trailing-sla)