### PR TITLE
JUCE suggestions

### DIFF
--- a/javascript/choc_javascript_QuickJS.h
+++ b/javascript/choc_javascript_QuickJS.h
@@ -220,18 +220,6 @@ static inline int clz32(unsigned int a)
 }
 
 /* WARNING: undefined if a = 0 */
-static inline int clz64(uint64_t a)
-{
-   #if _MSC_VER
-    unsigned long i;
-    _BitScanReverse64 (&i, a);
-    return 63 ^ i;
-   #else
-    return __builtin_clzll(a);
-   #endif
-}
-
-/* WARNING: undefined if a = 0 */
 static inline int ctz32(unsigned int a)
 {
    #if _MSC_VER
@@ -240,18 +228,6 @@ static inline int ctz32(unsigned int a)
     return 31 ^ i;
    #else
     return __builtin_ctz(a);
-   #endif
-}
-
-/* WARNING: undefined if a = 0 */
-static inline int ctz64(uint64_t a)
-{
-   #if _MSC_VER
-    unsigned long i;
-    _BitScanForward64 (&i, a);
-    return 63 ^ i;
-   #else
-    return __builtin_ctzll(a);
    #endif
 }
 

--- a/platform/choc_DisableAllWarnings.h
+++ b/platform/choc_DisableAllWarnings.h
@@ -73,6 +73,8 @@
  #pragma GCC diagnostic ignored "-Wuse-after-free"
  #pragma GCC diagnostic ignored "-Warray-bounds"
  #pragma GCC diagnostic ignored "-Wvolatile"
+ #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+ #pragma GCC diagnostic ignored "-Wfloat-equal"
  #ifndef __MINGW32__
   #pragma GCC diagnostic ignored "-Wredundant-move"
  #endif

--- a/platform/choc_ObjectiveCHelpers.h
+++ b/platform/choc_ObjectiveCHelpers.h
@@ -19,7 +19,7 @@
 #ifndef CHOC_OBJC_HELPERS_HEADER_INCLUDED
 #define CHOC_OBJC_HELPERS_HEADER_INCLUDED
 
-#include "../platform/choc_Platform.h"
+#include "choc_Platform.h"
 
 #if CHOC_APPLE
 
@@ -28,7 +28,7 @@
 #include <objc/message.h>
 #include <type_traits>
 
-#include "../platform/choc_Assert.h"
+#include "choc_Assert.h"
 
 
 //==============================================================================


### PR DESCRIPTION
These commits are designed to prevent JUCE needing to add any additional workarounds when including choc.

The most controversial of which I suspect will be the two changes required to make the MSVC code analyser happy but I was keen to not simply disable the warnings using pragmas, add heap allocation where there wasn't already heap allocation, or add breaking changes (which I believe I've avoided).