### PR TITLE
More JUCE suggestions

### DIFF
--- a/containers/choc_Value.h
+++ b/containers/choc_Value.h
@@ -2442,6 +2442,12 @@ void ValueView::serialise (OutputStream& output) const
      uint8_t* localCopy = nullptr;
 
     #if _MSC_VER
+
+     #ifdef __clang__
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wlanguage-extension-token"
+     #endif
+
      __try
      {
          localCopy = (uint8_t*) _alloca (dataSize);
@@ -2450,6 +2456,11 @@ void ValueView::serialise (OutputStream& output) const
      {
          throwError ("Stack overflow");
      }
+
+     #ifdef __clang__
+      #pragma clang diagnostic pop
+     #endif
+
     #else
      localCopy = (uint8_t*) alloca (dataSize);
     #endif

--- a/math/choc_MathHelpers.h
+++ b/math/choc_MathHelpers.h
@@ -30,7 +30,7 @@
   #pragma intrinsic (_BitScanReverse64)
  #endif
 
- #ifdef _M_X64
+ #if defined (_M_X64) && ! defined (_M_ARM64EC)
   #pragma intrinsic (_umul128)
   #define CHOC_HAS_UMUL128 1
  #endif


### PR DESCRIPTION
Well just as I got those other fixes through, more builds were added to our CI 😆 

For the pragma ignore, I'm struggling to see how to avoid an ignore of some description. The ignore in this PR is required because of the use of `__try` when building with clang on windows (I think with pedantic warnings enabled, I would need to check exactly what triggered it). If we don't use `__try` then MSVC will complain, suggesting to use `_malloca` instead, but that will allocate on the heap for anything over 1024 bytes by default. We could instead ignore the MSVC warning and drop the try/except?

The other issue is fairly simple `_M_X64` is defined for arm64ec builds (but not arm64). In theory using `_umul128` should work but because there is no equivalent intrinsic for arm64 a warning is triggered `C4163: 'UnsignedMultiply128': not available as an intrinsic function`. `_M_ARM64EC` is only defined for am64ec builds so we can easily detect the edge case.