### PR TITLE
Gift that keeps giving

### DIFF
--- a/containers/choc_Value.h
+++ b/containers/choc_Value.h
@@ -2439,28 +2439,15 @@ void ValueView::serialise (OutputStream& output) const
         return;
     }
 
-    uint8_t* localCopy = nullptr;
-
-   #if _MSC_VER
-    #ifdef __clang__
-     #pragma clang diagnostic push
-     #pragma clang diagnostic ignored "-Wlanguage-extension-token"
-    #endif
-
-    __try
-    {
-        localCopy = (uint8_t*) _alloca (dataSize);
-    }
-    __except (1)
-    {
-        throwError ("Stack overflow");
-    }
-
-    #ifdef __clang__
-     #pragma clang diagnostic pop
-    #endif
+   #if defined (_MSC_VER)
+    #pragma warning (push)
+    #pragma warning (disable: 6255)
+    auto* localCopy = (uint8_t*) _alloca (dataSize);
+    #pragma warning (pop)
+   #elif defined (__MINGW32__)
+    auto* localCopy = (uint8_t*) _alloca (dataSize);
    #else
-    localCopy = (uint8_t*) alloca (dataSize);
+    auto* localCopy = (uint8_t*) alloca (dataSize);
    #endif
 
     check (localCopy != nullptr, "Stack allocation failed");

--- a/gui/choc_DesktopWindow.h
+++ b/gui/choc_DesktopWindow.h
@@ -432,14 +432,7 @@ struct DesktopWindow::Pimpl
 //==============================================================================
 #elif CHOC_WINDOWS
 
-#undef  WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#undef  NOMINMAX
-#define NOMINMAX
-#define Rectangle Rectangle_renamed_to_avoid_name_collisions
-#include <windows.h>
-#undef Rectangle
-
+#include "../platform/choc_Windows.h"
 #include "../platform/choc_DynamicLibrary.h"
 
 namespace choc::ui

--- a/gui/choc_MessageLoop.h
+++ b/gui/choc_MessageLoop.h
@@ -368,13 +368,7 @@ struct Timer::Pimpl
 //==============================================================================
 #elif CHOC_WINDOWS
 
-#undef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#undef  NOMINMAX
-#define NOMINMAX
-#define Rectangle Rectangle_renamed_to_avoid_name_collisions
-#include <windows.h>
-#undef Rectangle
+#include "../platform/choc_Windows.h"
 
 namespace choc::messageloop
 {

--- a/javascript/choc_javascript_QuickJS.h
+++ b/javascript/choc_javascript_QuickJS.h
@@ -60,13 +60,7 @@
 #endif
 
 #if _MSC_VER
- #undef  WIN32_LEAN_AND_MEAN
- #define WIN32_LEAN_AND_MEAN
- #undef  NOMINMAX
- #define NOMINMAX
- #define Rectangle Rectangle_renamed_to_avoid_name_collisions
- #include <windows.h>
- #undef Rectangle
+ #include "../platform/choc_Windows.h"
 #elif ! defined(EMSCRIPTEN)
  #include <sys/time.h>
 #endif

--- a/platform/choc_MemoryDLL.h
+++ b/platform/choc_MemoryDLL.h
@@ -81,13 +81,7 @@ private:
 
 #include <vector>
 #include <unordered_map>
-#undef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#undef  NOMINMAX
-#define NOMINMAX
-#define Rectangle Rectangle_renamed_to_avoid_name_collisions
-#include <windows.h>
-#undef Rectangle
+#include "../platform/choc_Windows.h"
 
 namespace choc::memory
 {

--- a/platform/choc_Platform.h
+++ b/platform/choc_Platform.h
@@ -26,6 +26,9 @@
       - CHOC_LINUX
       - CHOC_OSX
       - CHOC_IOS
+      - CHOC_BSD
+      - CHOC_POSIX
+      - CHOC_EMSCRIPTEN
     ...based on the current operating system.
 
     It also declares a string literal macro CHOC_OPERATING_SYSTEM_NAME

--- a/platform/choc_Windows.h
+++ b/platform/choc_Windows.h
@@ -1,0 +1,30 @@
+//
+//    ██████ ██   ██  ██████   ██████
+//   ██      ██   ██ ██    ██ ██            ** Classy Header-Only Classes **
+//   ██      ███████ ██    ██ ██
+//   ██      ██   ██ ██    ██ ██           https://github.com/Tracktion/choc
+//    ██████ ██   ██  ██████   ██████
+//
+//   CHOC is (C)2022 Tracktion Corporation, and is offered under the terms of the ISC license:
+//
+//   Permission to use, copy, modify, and/or distribute this software for any purpose with or
+//   without fee is hereby granted, provided that the above copyright notice and this permission
+//   notice appear in all copies. THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+//   WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+//   AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+//   CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+//   WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+//   CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#ifndef CHOC_WINDOWS_HEADER_INCLUDED
+#define CHOC_WINDOWS_HEADER_INCLUDED
+
+#undef  WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#undef  NOMINMAX
+#define NOMINMAX
+#define Rectangle Rectangle_renamed_to_avoid_name_collisions
+#include <windows.h>
+#undef Rectangle
+
+#endif // CHOC_WINDOWS_HEADER_INCLUDED


### PR DESCRIPTION
Unfortunately the recent change to avoid `GetExceptionCode() == STATUS_STACK_OVERFLOW` caused another warning
(`warning C6320: Exception-filter expression is the constant EXCEPTION_EXECUTE_HANDLER. This might mask exceptions that were not intended to be handled.`) however, as you had already discovered the use of `GetExceptionCode()` and `STATUS_STACK_OVERFLOW` were also causing issues because `Windows.h` wasn't included. In this PR I think I've managed to fix all those issues 🤞 and avoid any pragma ignore warning malarky too. Hopefully that will be the last of it!