### PR TITLE
Add cstring include in choc_PoolAllocator.h

### DIFF
--- a/choc/memory/choc_PoolAllocator.h
+++ b/choc/memory/choc_PoolAllocator.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <array>
 #include <cstdlib>
+#include <cstring>
 #include "../platform/choc_Assert.h"
 
 namespace choc::memory


### PR DESCRIPTION
Hey @julianstorer, quick nudge here.

I'm getting a compilation error on ubuntu-latest with the PoolAllocator class. It looks like it depends on memcpy from `<cstring>` but doesn't include it itself. In the choc tests, one of the other includes (Value) pulls in cstring before the poolAllocator include, so you wouldn't see it on CHOC CI.

P.S.– thanks for your work here, it's a really useful library!