### PR TITLE
Added some extra MSVC warnings to choc_DisableAllWarnings.h

### DIFF
--- a/choc/platform/choc_DisableAllWarnings.h
+++ b/choc/platform/choc_DisableAllWarnings.h
@@ -85,6 +85,7 @@
  #pragma warning (disable: 2440)
  #pragma warning (disable: 2664)
  #pragma warning (disable: 4244)
+ #pragma warning (disable: 4245)
  #pragma warning (disable: 4701)
  #pragma warning (disable: 4702)
  #pragma warning (disable: 4706)
@@ -99,5 +100,7 @@
  #pragma warning (disable: 6340)
  #pragma warning (disable: 6385)
  #pragma warning (disable: 6386)
+ #pragma warning (disable: 26437)
+ #pragma warning (disable: 26816)
  #pragma warning (disable: 28182)
 #endif


### PR DESCRIPTION
I've encountered a few MSVC warnings in my current project's deps that this header didn't cover yet - added those!

[4245](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4245?view=msvc-170) "'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch"
[26437](https://learn.microsoft.com/en-us/cpp/code-quality/c26437?view=msvc-170) "Do not slice"
[26816](https://learn.microsoft.com/en-us/cpp/code-quality/c26816?view=msvc-170) "The pointer points to memory allocated on the stack (ES.65)"